### PR TITLE
Improve efficiency with hash-based vocabulary lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = gcc
 CFLAGS = -Wall -g  -I./include # -Wall enables warnings, -g adds debugging info
 
 main: main.o network.o dataParser.o
-	$(CC) $(CFLAGS) -o main main.o network.o dataParser.o
+	$(CC) $(CFLAGS) -o main main.o network.o dataParser.o -lm
 
 main.o: main.c ./network/network.h ./dataParsing/dataParser.h ./dataParsing/vocabHash.h
 	$(CC) $(CFLAGS) -c main.c

--- a/network/network.c
+++ b/network/network.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 // Sigmoid activation function
 float sigmoid(float x) {


### PR DESCRIPTION
## Summary
- speed up text vectorization with hash index map
- link math library in Makefile
- include `<stdint.h>` for binary model code

## Testing
- `make`
- `./main <<EOF
2
EOF` *(interrupted during training)*

------
https://chatgpt.com/codex/tasks/task_e_684caf51303483288b4506b6f5399b17